### PR TITLE
Fix typos in SynthesisMeta.json

### DIFF
--- a/leveledlistresolver/SynthesisMeta.json
+++ b/leveledlistresolver/SynthesisMeta.json
@@ -1,8 +1,8 @@
 {
   "Nickname": "leveledlistresolver",
   "Visibility": "Visible",
-  "OneLineDescription": "A Patcher for resolving levelled list conflicts.",
-  "LongDescription": "Patcher for resolving levelled list conflicts.",
+  "OneLineDescription": "A Patcher for resolving leveled list conflicts.",
+  "LongDescription": "Patcher for resolving leveled list conflicts.",
   "PreferredAutoVersioning": "Default",
   "RequiredMods": []
 }


### PR DESCRIPTION
Sorry, just happened to see it in the Synthesis Git patcher 'gallery' :P